### PR TITLE
fix: yarn dev fails due to multiline description without quotes

### DIFF
--- a/src/solutions/real-estate/real-estate.md
+++ b/src/solutions/real-estate/real-estate.md
@@ -1,7 +1,7 @@
 ---
 title: "Real Estate"
-description: Castmill is the perfect partner for real estate agencies. We can integrate
-with existing systems and provide you a powerful digital signage solution.
+description: "Castmill is the perfect partner for real estate agencies. We can integrate
+with existing systems and provide you a powerful digital signage solution."
 cover: /solutions/real-estate/real-estate-digital.jpg
 caption: "A digital solution blends seemless in any storefront."
 tags: "solutions"


### PR DESCRIPTION
yarn dev failed on my machine.
<img width="501" alt="image" src="https://user-images.githubusercontent.com/1486110/185764275-50b16b7a-2c37-4af9-8a32-53291294463f.png">

This must have worked on your machine and in the build environment. Strange...