### PR TITLE
fix: use right header style in bright mode

### DIFF
--- a/src/_includes/blog.njk
+++ b/src/_includes/blog.njk
@@ -6,7 +6,7 @@ layout: "base.njk"
         <header class="col-span-full mb-10">
             <div class="col-span-full inset-x-0 text-slate-700 dark:text-slate-400 sm:text-center mb-2 text-sm">{{ date | postDateLong }}</div>
 
-            <h1 class="col-span-full text-3xl sm:mb-6 sm:text-4xl sm:text-center xl:mb-16 font-extrabold tracking-tight text-slate-900 text-slate-200">
+            <h1 class="col-span-full text-3xl sm:mb-6 sm:text-4xl sm:text-center xl:mb-16 font-extrabold tracking-tight text-slate-900 dark:text-slate-200">
                 {{ title }}
             </h1>
 

--- a/src/_includes/page.njk
+++ b/src/_includes/page.njk
@@ -5,7 +5,7 @@ layout: "base.njk"
     <article class="relative pt-10 max-w-4xl mx-auto xl:max-w-none">
         <header class="col-span-full mb-10">
 
-            <h1 class="col-span-full text-8xl sm:text-4xl sm:text-center xl:mb-16 font-extrabold tracking-tight text-slate-900 text-slate-200">
+            <h1 class="col-span-full text-8xl sm:text-4xl sm:text-center xl:mb-16 font-extrabold tracking-tight text-slate-900 dark:text-slate-200">
                 {{ title }}
             </h1>
 


### PR DESCRIPTION
Currently the dark mode header style is used all the time. This PR fixes that